### PR TITLE
Topic/itext 2.1.7.js7

### DIFF
--- a/.project
+++ b/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>iText217js6_SEE</name>
+	<name>iText217js7_SEE</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding//core/TIBCO.Software.changes.txt=UTF-8

--- a/README.md
+++ b/README.md
@@ -4,4 +4,9 @@ iText library used by Jasper Reports as of version 2.1.7 modified by JasperSoft
 The base version in this repository comes from JasperSoft:
 http://jasperreports.sourceforge.net/maven2/com/lowagie/itext/2.1.7.js6-SNAPSHOT/
 
+Later the sources were updated from the newer JasperSoft repository:
+http://jaspersoft.jfrog.io/jaspersoft/third-party-ce-artifacts/com/lowagie/itext/2.1.7.js7/
+specifically source JAR:
+http://jaspersoft.jfrog.io/jaspersoft/third-party-ce-artifacts/com/lowagie/itext/2.1.7.js7/itext-2.1.7.js7-sources.jar
+
 Seeburger changes include making it compatible with newer versions of the BouncyCastle cryptography provider.

--- a/README.md
+++ b/README.md
@@ -9,4 +9,16 @@ http://jaspersoft.jfrog.io/jaspersoft/third-party-ce-artifacts/com/lowagie/itext
 specifically source JAR:
 http://jaspersoft.jfrog.io/jaspersoft/third-party-ce-artifacts/com/lowagie/itext/2.1.7.js7/itext-2.1.7.js7-sources.jar
 
-Seeburger changes include making it compatible with newer versions of the BouncyCastle cryptography provider.
+Seeburger changes include making it compatible with newer versions of the BouncyCastle cryptography provider:
+
+03 Feb 2021, modified:
+core/com/lowagie/text/pdf/PdfPKCS7.java
+core/com/lowagie/text/pdf/PdfPublicKeySecurityHandler.java
+Purpose: Compatibility with BouncyCastle 1.68
+
+Additional files/directories modified/added for the sake of DevOps (not core functionality):
+.classpath
+.project
+.settings
+pom.xml
+README.md

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ http://jaspersoft.jfrog.io/jaspersoft/third-party-ce-artifacts/com/lowagie/itext
 
 Seeburger changes include making it compatible with newer versions of the BouncyCastle cryptography provider:
 
+```
 03 Feb 2021, modified:
 core/com/lowagie/text/pdf/PdfPKCS7.java
 core/com/lowagie/text/pdf/PdfPublicKeySecurityHandler.java
@@ -22,3 +23,4 @@ Additional files/directories modified/added for the sake of DevOps (not core fun
 .settings
 pom.xml
 README.md
+```

--- a/ant/.ant.properties
+++ b/ant/.ant.properties
@@ -14,7 +14,7 @@ jcommon.jar=${itext.lib}/jcommon.jar
 servlet.jar=${itext.lib}/servlet.jar
 
 bc.jdk=jdk15on
-bc.version=1.52
+bc.version=1.62
 
 lib.bcmail=bcmail-${bc.jdk}-${bc.version}.jar
 lib.bcprov=bcprov-${bc.jdk}-${bc.version}.jar

--- a/core/TIBCO.Software.changes.txt
+++ b/core/TIBCO.Software.changes.txt
@@ -1,6 +1,6 @@
 
 TIBCO Software Inc. has made modifications to certain files of the Original Code of this component as further described below.
-The Original Code is “iText, a free JAVA-PDF library�?, by Initial Developer, Bruno Lowagie, and Co-Developer, Paulo Soares.
+The Original Code is “iText, a free JAVA-PDF library”, by Initial Developer, Bruno Lowagie, and Co-Developer, Paulo Soares.
 
 
 #1 Fix for transparency issue with setClip method in PdfGraphics2D

--- a/core/TIBCO.Software.changes.txt
+++ b/core/TIBCO.Software.changes.txt
@@ -1,6 +1,6 @@
 
 TIBCO Software Inc. has made modifications to certain files of the Original Code of this component as further described below.
-The Original Code is “iText, a free JAVA-PDF library”, by Initial Developer, Bruno Lowagie, and Co-Developer, Paulo Soares.
+The Original Code is “iText, a free JAVA-PDF library�?, by Initial Developer, Bruno Lowagie, and Co-Developer, Paulo Soares.
 
 
 #1 Fix for transparency issue with setClip method in PdfGraphics2D
@@ -39,3 +39,8 @@ com/lowagie/text/pdf/OcspClientBouncyCastle.java
 com/lowagie/text/pdf/PdfPKCS7.java
 com/lowagie/text/pdf/PdfPublicKeySecurityHandler.java
 com/lowagie/text/pdf/PdfReader.java
+
+#7 Upgrade Bouncy Castle dependencies to jdk15on-1.62
+Date: July 3, 2019
+Modified files:
+com/lowagie/text/pdf/PdfPublicKeySecurityHandler

--- a/pom.xml
+++ b/pom.xml
@@ -8,10 +8,20 @@
 
 	 <properties>
         <bc.version>1.68</bc.version>
+        <osgi.imported.packages>
+            !junit,
+            !junit.*,
+            !com.apple.*,
+            !com.lowagie.toolbox,
+            !com.lowagie.text.*,
+            org.bouncycastle.*,
+            *
+        </osgi.imported.packages>
+        <osgi.exported.packages>!org.bouncycastle.*,*</osgi.exported.packages>
      </properties>
 
 	<name>iText, a Free Java-PDF library</name>
-	<version>2.1.7.js6.SEE3-SNAPSHOT</version>
+	<version>2.1.7.js7.SEE3-SNAPSHOT</version>
 	<description>iText, a free Java-PDF library</description>
 	<url>http://www.lowagie.com/iText/</url>
 	<mailingLists>
@@ -92,7 +102,7 @@
 	</dependencies>
 	<build>
 	<sourceDirectory>core</sourceDirectory>
-    <resources>
+       <resources>
             <resource>
                 <directory>core</directory>
                 <includes>
@@ -111,22 +121,51 @@
             </resource>
         </resources>
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-jar-plugin</artifactId>
-				<configuration>
-					<archive>
-						<manifest>
-							<mainClass>
-								com.lowagie.tools.ToolboxAvailable
-							</mainClass>
-						</manifest>
-					</archive>
-				</configuration>
-			</plugin>
+		  <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.5.1</version>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                        <configuration>
+                            <manifestLocation>${project.build.outputDirectory}/META-INF</manifestLocation>
+                            <instructions>
+		                        <Export-Package>${osgi.exported.packages}</Export-Package>
+        		                <Import-Package>${osgi.imported.packages}</Import-Package>
+								<_nouses>true</_nouses>
+                                <_noee>true</_noee>
+                            </instructions>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 			<plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>2.10.3</version>
                     <executions>
                         <execution>
                             <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
             !com.apple.*,
             !com.lowagie.toolbox,
             !com.lowagie.text.*,
-            org.bouncycastle.*,
+            org.bouncycastle.*;version="[1.63,2)",
             *
         </osgi.imported.packages>
         <osgi.exported.packages>!org.bouncycastle.*,*</osgi.exported.packages>


### PR DESCRIPTION
Sources updated to JS7 level.
Build now produces an OSGi bundle.