### PR TITLE
[Feature #133051] Upgrade the Jasper Reports library 6.15 to 6.19.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ http://jaspersoft.jfrog.io/jaspersoft/third-party-ce-artifacts/com/lowagie/itext
 specifically source JAR:
 http://jaspersoft.jfrog.io/jaspersoft/third-party-ce-artifacts/com/lowagie/itext/2.1.7.js7/itext-2.1.7.js7-sources.jar
 
+Later the sources were updated to be the same as those of js9:
+https://jaspersoft.jfrog.io/ui/native/third-party-ce-artifacts/com/lowagie/itext/2.1.7.js9/
+specifically source JAR:
+https://jaspersoft.jfrog.io/artifactory/third-party-ce-artifacts/com/lowagie/itext/2.1.7.js9/itext-2.1.7.js9-sources.jar
+
 Seeburger changes include making it compatible with newer versions of the BouncyCastle cryptography provider:
 
 ```
@@ -17,4 +22,11 @@ Purpose: Compatibility with BouncyCastle 1.68
 Additional files/directories modified/added for the sake of DevOps (not core functionality):
 pom.xml
 README.md
+
+15 Apr 2022
+core/com/lowagie/text/pdf/PdfPKCS7.java
+core/com/lowagie/text/pdf/PdfPublicKeySecurityHandler.java
+Purpose: Synchronizing sources to be the same as version JS9
+https://jaspersoft.jfrog.io/artifactory/third-party-ce-artifacts/com/lowagie/itext/2.1.7.js9/itext-2.1.7.js9-sources.jar
+
 ```

--- a/core/TIBCO.Software.changes.txt
+++ b/core/TIBCO.Software.changes.txt
@@ -44,3 +44,13 @@ com/lowagie/text/pdf/PdfReader.java
 Date: July 3, 2019
 Modified files:
 com/lowagie/text/pdf/PdfPublicKeySecurityHandler
+#8 Upgrade Bouncy Castle dependencies to jdk15on-1.64
+Date: June 30, 2020
+Modified files:
+N/A
+
+#9 Upgrade Bouncy Castle dependencies to jdk15on-1.68
+Date: September 21, 2021
+Modified files:
+com/lowagie/text/pdf/PdfPKCS7.java
+com/lowagie/text/pdf/PdfPublicKeySecurityHandler.java

--- a/core/com/lowagie/text/pdf/PdfPKCS7.java
+++ b/core/com/lowagie/text/pdf/PdfPKCS7.java
@@ -17,7 +17,7 @@
  * Co-Developer of the code is Paulo Soares. Portions created by the Co-Developer
  * are Copyright (C) 2000, 2001, 2002 by Paulo Soares. All Rights Reserved.
  *
- * Contributor(s): Certain Contributions were created by TIBCO Software Inc. Such
+ * Contributor(s): Certain Contributions were created by TIBCO Software Inc. Such 
  * Contributions are Copyright (C) 2017 by TIBCO Software Inc. All Rights Reserved.
  * All the names of the other contributors are added in the source code
  * where applicable.
@@ -77,25 +77,22 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
-import org.bouncycastle.asn1.ASN1Encodable;
+//TIBCO Software #9 : Part 1 - START
 import org.bouncycastle.asn1.ASN1EncodableVector;
 // TIBCO Software #6 : Part 4 - START
 import org.bouncycastle.asn1.ASN1Encoding;
+import org.bouncycastle.asn1.ASN1Enumerated;
 import org.bouncycastle.asn1.ASN1InputStream;
+import org.bouncycastle.asn1.ASN1Integer;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1OutputStream;
 import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.ASN1Set;
 import org.bouncycastle.asn1.ASN1String;
 import org.bouncycastle.asn1.ASN1TaggedObject;
-
-import org.bouncycastle.asn1.ASN1Enumerated;
-
-import org.bouncycastle.asn1.ASN1Integer;
 import org.bouncycastle.asn1.DERNull;
-import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.DEROctetString;
-/* import org.bouncycastle.asn1.DEROutputStream; */
 import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.DERSet;
 import org.bouncycastle.asn1.DERTaggedObject;
@@ -115,9 +112,8 @@ import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.tsp.MessageImprint;
 import org.bouncycastle.asn1.x509.X509Extensions;
 import org.bouncycastle.cert.ocsp.BasicOCSPResp;
-import org.bouncycastle.cert.ocsp.CertificateID;
-import org.bouncycastle.cert.ocsp.SingleResp;
 //TIBCO Software #6 : Part 4 - END
+//TIBCO Software #9 : Part 1 - END
 import org.bouncycastle.tsp.TimeStampToken;
 
 /**
@@ -145,7 +141,7 @@ public class PdfPKCS7 {
     private byte externalDigest[];
     private byte externalRSAdata[];
     private String provider;
-
+    
     private static final String ID_PKCS7_DATA = "1.2.840.113549.1.7.1";
     private static final String ID_PKCS7_SIGNED_DATA = "1.2.840.113549.1.7.2";
     private static final String ID_RSA = "1.2.840.113549.1.1.1";
@@ -158,28 +154,28 @@ public class PdfPKCS7 {
      * Holds value of property reason.
      */
     private String reason;
-
+    
     /**
      * Holds value of property location.
      */
     private String location;
-
+    
     /**
      * Holds value of property signDate.
      */
     private Calendar signDate;
-
+    
     /**
      * Holds value of property signName.
      */
     private String signName;
-
+    
     private TimeStampToken timeStampToken;
-
+    
     private static final HashMap digestNames = new HashMap();
     private static final HashMap algorithmNames = new HashMap();
     private static final HashMap allowedDigests = new HashMap();
-
+    
     static {
         digestNames.put("1.2.840.113549.2.5", "MD5");
         digestNames.put("1.2.840.113549.2.2", "MD2");
@@ -208,7 +204,7 @@ public class PdfPKCS7 {
         digestNames.put("1.3.36.3.3.1.3", "RIPEMD128");
         digestNames.put("1.3.36.3.3.1.2", "RIPEMD160");
         digestNames.put("1.3.36.3.3.1.4", "RIPEMD256");
-
+        
         algorithmNames.put("1.2.840.113549.1.1.1", "RSA");
         algorithmNames.put("1.2.840.10040.4.1", "DSA");
         algorithmNames.put("1.2.840.113549.1.1.2", "RSA");
@@ -224,7 +220,7 @@ public class PdfPKCS7 {
         algorithmNames.put("1.3.36.3.3.1.3", "RSA");
         algorithmNames.put("1.3.36.3.3.1.2", "RSA");
         algorithmNames.put("1.3.36.3.3.1.4", "RSA");
-
+        
         allowedDigests.put("MD5", "1.2.840.113549.2.5");
         allowedDigests.put("MD2", "1.2.840.113549.2.2");
         allowedDigests.put("SHA1", "1.3.14.3.2.26");
@@ -246,7 +242,7 @@ public class PdfPKCS7 {
         allowedDigests.put("RIPEMD256", "1.3.36.3.2.3");
         allowedDigests.put("RIPEMD-256", "1.3.36.3.2.3");
     }
-
+    
     /**
      * Gets the digest name for a certain id
      * @param oid	an id (for instance "1.2.840.113549.2.5")
@@ -260,7 +256,7 @@ public class PdfPKCS7 {
         else
             return ret;
     }
-
+    
     /**
      * Gets the algorithm name for a certain id.
      * @param oid	an id (for instance "1.2.840.113549.1.1.1")
@@ -274,7 +270,7 @@ public class PdfPKCS7 {
         else
             return ret;
     }
-
+    
     /**
      * Gets the timestamp token if there is one.
      * @return the timestamp token or null
@@ -283,7 +279,7 @@ public class PdfPKCS7 {
     public TimeStampToken getTimeStampToken() {
     	return timeStampToken;
     }
-
+    
     /**
      * Gets the timestamp date
      * @return	a date
@@ -297,13 +293,13 @@ public class PdfPKCS7 {
         cal.setTime(date);
         return cal;
     }
-
+    
     /**
      * Verifies a signature using the sub-filter adbe.x509.rsa_sha1.
      * @param contentsKey the /Contents key
      * @param certsKey the /Cert key
      * @param provider the provider or <code>null</code> for the default provider
-     */
+     */    
     public PdfPKCS7(byte[] contentsKey, byte[] certsKey, String provider) {
         try {
             this.provider = provider;
@@ -325,9 +321,9 @@ public class PdfPKCS7 {
             throw new ExceptionConverter(e);
         }
     }
-
+    
     private BasicOCSPResp basicResp;
-
+    
     /**
      * Gets the OCSP basic response if there is one.
      * @return the OCSP basic response or null
@@ -336,15 +332,17 @@ public class PdfPKCS7 {
     public BasicOCSPResp getOcsp() {
         return basicResp;
     }
-
+    
     private void findOcsp(ASN1Sequence seq) throws IOException {
         basicResp = null;
         boolean ret = false;
         while (true) {
-            if ((seq.getObjectAt(0) instanceof ASN1ObjectIdentifier)
+        	//TIBCO Software #9 : Part 2 - START
+            if ((seq.getObjectAt(0) instanceof ASN1ObjectIdentifier) 
                 && ((ASN1ObjectIdentifier)seq.getObjectAt(0)).getId().equals(OCSPObjectIdentifiers.id_pkix_ocsp_basic.getId())) {
                 break;
             }
+            //TIBCO Software #9 : Part 2 - END
             ret = true;
             for (int k = 0; k < seq.size(); ++k) {
                 if (seq.getObjectAt(k) instanceof ASN1Sequence) {
@@ -371,13 +369,13 @@ public class PdfPKCS7 {
         BasicOCSPResponse resp = BasicOCSPResponse.getInstance(inp.readObject());
         basicResp = new BasicOCSPResp(resp);
     }
-
+    
     /**
      * Verifies a signature using the sub-filter adbe.pkcs7.detached or
      * adbe.pkcs7.sha1.
      * @param contentsKey the /Contents key
      * @param provider the provider or <code>null</code> for the default provider
-     */
+     */    
     public PdfPKCS7(byte[] contentsKey, String provider) {
         try {
             this.provider = provider;
@@ -400,7 +398,9 @@ public class PdfPKCS7 {
                 throw new IllegalArgumentException("Not a valid PKCS#7 object - not a sequence");
             }
             ASN1Sequence signedData = (ASN1Sequence)pkcs;
+            //TIBCO Software #9 : Part 3 - START
             ASN1ObjectIdentifier objId = (ASN1ObjectIdentifier)signedData.getObjectAt(0);
+            //TIBCO Software #9 : Part 3 - END
             if (!objId.getId().equals(ID_PKCS7_SIGNED_DATA))
                 throw new IllegalArgumentException("Not a valid PKCS#7 object - not signed data");
             ASN1Sequence content = (ASN1Sequence)((DERTaggedObject)signedData.getObjectAt(1)).getObject();
@@ -412,7 +412,9 @@ public class PdfPKCS7 {
             //     last - signerInfos
 
             // the version
+            //TIBCO Software #9 : Part 4 - START
             version = ((ASN1Integer)content.getObjectAt(0)).getValue().intValue();
+            //TIBCO Software #9 : Part 4 - END
 
             // the digestAlgorithms
             digestalgos = new HashSet();
@@ -420,7 +422,9 @@ public class PdfPKCS7 {
             while (e.hasMoreElements())
             {
                 ASN1Sequence s = (ASN1Sequence)e.nextElement();
+                //TIBCO Software #9 : Part 5 - START
                 ASN1ObjectIdentifier o = (ASN1ObjectIdentifier)s.getObjectAt(0);
+                //TIBCO Software #9 : Part 5 - END
                 digestalgos.add(o.getId());
             }
 
@@ -453,10 +457,12 @@ public class PdfPKCS7 {
             //     2 - the digest algorithm
             //     3 or 4 - digestEncryptionAlgorithm
             //     4 or 5 - encryptedDigest
+            //TIBCO Software #9 : Part 6 - START
             signerversion = ((ASN1Integer)signerInfo.getObjectAt(0)).getValue().intValue();
             // Get the signing certificate
             ASN1Sequence issuerAndSerialNumber = (ASN1Sequence)signerInfo.getObjectAt(1);
             BigInteger serialNumber = ((ASN1Integer)issuerAndSerialNumber.getObjectAt(1)).getValue();
+            //TIBCO Software #9 : Part 6 - END
             for (Iterator i = certs.iterator(); i.hasNext();) {
                 X509Certificate cert = (X509Certificate)i.next();
                 if (serialNumber.equals(cert.getSerialNumber())) {
@@ -468,7 +474,9 @@ public class PdfPKCS7 {
                 throw new IllegalArgumentException("Can't find signing certificate with serial " + serialNumber.toString(16));
             }
             signCertificateChain();
+            //TIBCO Software #9 : Part 7 - START
             digestAlgorithm = ((ASN1ObjectIdentifier)((ASN1Sequence)signerInfo.getObjectAt(2)).getObjectAt(0)).getId();
+            //TIBCO Software #9 : Part 7 - END
             next = 3;
             if (signerInfo.getObjectAt(next) instanceof ASN1TaggedObject) {
                 ASN1TaggedObject tagsig = (ASN1TaggedObject)signerInfo.getObjectAt(next);
@@ -479,11 +487,13 @@ public class PdfPKCS7 {
 
                 for (int k = 0; k < sseq.size(); ++k) {
                     ASN1Sequence seq2 = (ASN1Sequence)sseq.getObjectAt(k);
+                    //TIBCO Software #9 : Part 8 - START
                     if (((ASN1ObjectIdentifier)seq2.getObjectAt(0)).getId().equals(ID_MESSAGE_DIGEST)) {
                         ASN1Set set = (ASN1Set)seq2.getObjectAt(1);
                         digestAttr = ((DEROctetString)set.getObjectAt(0)).getOctets();
                     }
                     else if (((ASN1ObjectIdentifier)seq2.getObjectAt(0)).getId().equals(ID_ADBE_REVOCATION)) {
+                    //TIBCO Software #9 : Part 8 - END
                         ASN1Set setout = (ASN1Set)seq2.getObjectAt(1);
                         ASN1Sequence seqout = (ASN1Sequence)setout.getObjectAt(0);
                         for (int j = 0; j < seqout.size(); ++j) {
@@ -499,7 +509,9 @@ public class PdfPKCS7 {
                     throw new IllegalArgumentException("Authenticated attribute is missing the digest.");
                 ++next;
             }
+            //TIBCO Software #9 : Part 9 - START
             digestEncryptionAlgorithm = ((ASN1ObjectIdentifier)((ASN1Sequence)signerInfo.getObjectAt(next++)).getObjectAt(0)).getId();
+            //TIBCO Software #9 : Part 9 - END
             digest = ((DEROctetString)signerInfo.getObjectAt(next++)).getOctets();
             if (next < signerInfo.size() && (signerInfo.getObjectAt(next) instanceof DERTaggedObject)) {
                 DERTaggedObject taggedObject = (DERTaggedObject) signerInfo.getObjectAt(next);
@@ -541,7 +553,7 @@ public class PdfPKCS7 {
      * @throws InvalidKeyException on error
      * @throws NoSuchProviderException on error
      * @throws NoSuchAlgorithmException on error
-     */
+     */    
     public PdfPKCS7(PrivateKey privKey, Certificate[] certChain, CRL[] crlList,
                     String hashAlgorithm, String provider, boolean hasRSAdata)
       throws InvalidKeyException, NoSuchProviderException,
@@ -549,17 +561,17 @@ public class PdfPKCS7 {
     {
         this.privKey = privKey;
         this.provider = provider;
-
+        
         digestAlgorithm = (String)allowedDigests.get(hashAlgorithm.toUpperCase());
         if (digestAlgorithm == null)
             throw new NoSuchAlgorithmException("Unknown Hash Algorithm "+hashAlgorithm);
-
+        
         version = signerversion = 1;
         certs = new ArrayList();
         crls = new ArrayList();
         digestalgos = new HashSet();
         digestalgos.add(digestAlgorithm);
-
+        
         //
         // Copy in the certificates and crls used to sign the private key.
         //
@@ -567,13 +579,13 @@ public class PdfPKCS7 {
         for (int i = 0;i < certChain.length;i++) {
             certs.add(certChain[i]);
         }
-
+        
         if (crlList != null) {
             for (int i = 0;i < crlList.length;i++) {
                 crls.add(crlList[i]);
             }
         }
-
+        
         if (privKey != null) {
             //
             // Now we have private key, find out what the digestEncryptionAlgorithm is.
@@ -620,7 +632,7 @@ public class PdfPKCS7 {
         else
             sig.update(buf, off, len);
     }
-
+    
     /**
      * Verify the digest.
      * @throws SignatureException on error
@@ -645,7 +657,7 @@ public class PdfPKCS7 {
         verified = true;
         return verifyResult;
     }
-
+    
     /**
      * Checks if the timestamp refers to this document.
      * @throws java.security.NoSuchAlgorithmException on error
@@ -661,7 +673,7 @@ public class PdfPKCS7 {
         boolean res = Arrays.equals(md, imphashed);
         return res;
     }
-
+    
     /**
      * Get all the X.509 certificates associated with this PKCS#7 object in no particular order.
      * Other certificates, from OCSP for example, will also be included.
@@ -670,7 +682,7 @@ public class PdfPKCS7 {
     public Certificate[] getCertificates() {
         return (X509Certificate[])certs.toArray(new X509Certificate[certs.size()]);
     }
-
+    
     /**
      * Get the X.509 sign certificate chain associated with this PKCS#7 object.
      * Only the certificates used for the main signature will be returned, with
@@ -681,7 +693,7 @@ public class PdfPKCS7 {
     public Certificate[] getSignCertificateChain() {
         return (X509Certificate[])signCerts.toArray(new X509Certificate[signCerts.size()]);
     }
-
+    
     private void signCertificateChain() {
         ArrayList cc = new ArrayList();
         cc.add(signCert);
@@ -714,7 +726,7 @@ public class PdfPKCS7 {
         }
         signCerts = cc;
     }
-
+    
     /**
      * Get the X.509 certificate revocation lists associated with this PKCS#7 object
      * @return the X.509 certificate revocation lists associated with this PKCS#7 object
@@ -722,7 +734,7 @@ public class PdfPKCS7 {
     public Collection getCRLs() {
         return crls;
     }
-
+    
     /**
      * Get the X.509 certificate actually used to sign the digest.
      * @return the X.509 certificate actually used to sign the digest
@@ -730,7 +742,7 @@ public class PdfPKCS7 {
     public X509Certificate getSigningCertificate() {
         return signCert;
     }
-
+    
     /**
      * Get the version of the PKCS#7 object. Always 1
      * @return the version of the PKCS#7 object. Always 1
@@ -738,7 +750,7 @@ public class PdfPKCS7 {
     public int getVersion() {
         return version;
     }
-
+    
     /**
      * Get the version of the PKCS#7 "SignerInfo" object. Always 1
      * @return the version of the PKCS#7 "SignerInfo" object. Always 1
@@ -746,7 +758,7 @@ public class PdfPKCS7 {
     public int getSigningInfoVersion() {
         return signerversion;
     }
-
+    
     /**
      * Get the algorithm used to calculate the message digest
      * @return the algorithm used to calculate the message digest
@@ -755,7 +767,7 @@ public class PdfPKCS7 {
         String dea = getAlgorithm(digestEncryptionAlgorithm);
         if (dea == null)
             dea = digestEncryptionAlgorithm;
-
+        
         return getHashAlgorithm() + "with" + dea;
     }
 
@@ -771,7 +783,7 @@ public class PdfPKCS7 {
      * Loads the default root certificates at &lt;java.home&gt;/lib/security/cacerts
      * with the default provider.
      * @return a <CODE>KeyStore</CODE>
-     */
+     */    
     public static KeyStore loadCacertsKeyStore() {
         return loadCacertsKeyStore(null);
     }
@@ -780,7 +792,7 @@ public class PdfPKCS7 {
      * Loads the default root certificates at &lt;java.home&gt;/lib/security/cacerts.
      * @param provider the provider or <code>null</code> for the default provider
      * @return a <CODE>KeyStore</CODE>
-     */
+     */    
     public static KeyStore loadCacertsKeyStore(String provider) {
         File file = new File(System.getProperty("java.home"), "lib");
         file = new File(file, "security");
@@ -803,7 +815,7 @@ public class PdfPKCS7 {
             try{if (fin != null) {fin.close();}}catch(Exception ex){}
         }
     }
-
+    
     /**
      * Verifies a single certificate.
      * @param cert the certificate to verify
@@ -811,7 +823,7 @@ public class PdfPKCS7 {
      * @param calendar the date or <CODE>null</CODE> for the current date
      * @return a <CODE>String</CODE> with the error description or <CODE>null</CODE>
      * if no error
-     */
+     */    
     public static String verifyCertificate(X509Certificate cert, Collection crls, Calendar calendar) {
         if (calendar == null)
             calendar = new GregorianCalendar();
@@ -831,7 +843,7 @@ public class PdfPKCS7 {
         }
         return null;
     }
-
+    
     /**
      * Verifies a certificate chain against a KeyStore.
      * @param certs the certificate chain
@@ -841,7 +853,7 @@ public class PdfPKCS7 {
      * @return <CODE>null</CODE> if the certificate chain could be validated or a
      * <CODE>Object[]{cert,error}</CODE> where <CODE>cert</CODE> is the
      * failed certificate and <CODE>error</CODE> is the error message
-     */
+     */    
     public static Object[] verifyCertificates(Certificate certs[], KeyStore keystore, Collection crls, Calendar calendar) {
         if (calendar == null)
             calendar = new GregorianCalendar();
@@ -898,7 +910,7 @@ public class PdfPKCS7 {
      * @param provider the provider or <CODE>null</CODE> to use the BouncyCastle provider
      * @return <CODE>true</CODE> is a certificate was found
      * @since	2.1.6
-     */
+     */    
     public static boolean verifyOcspCertificates(BasicOCSPResp ocsp, KeyStore keystore, String provider) {
         // TIBCO Software #6 : Part 7 - START
     	throw new UnsupportedOperationException();
@@ -923,7 +935,7 @@ public class PdfPKCS7 {
         return false;
 */    }
     // TIBCO Software #6 : Part 7 - END
-
+    
     /**
      * Verifies a timestamp against a KeyStore.
      * @param ts the timestamp
@@ -931,7 +943,7 @@ public class PdfPKCS7 {
      * @param provider the provider or <CODE>null</CODE> to use the BouncyCastle provider
      * @return <CODE>true</CODE> is a certificate was found
      * @since	2.1.6
-     */
+     */    
     public static boolean verifyTimestampCertificates(TimeStampToken ts, KeyStore keystore, String provider) {
         // TIBCO Software #6 : Part 8 - START
     	throw new UnsupportedOperationException();
@@ -956,7 +968,7 @@ public class PdfPKCS7 {
         return false;
 */    }
     // TIBCO Software #6 : Part 8 - END
-
+    
     /**
      * Retrieves the OCSP URL from the given certificate.
      * @param certificate the certificate
@@ -972,14 +984,16 @@ public class PdfPKCS7 {
             if (obj == null) {
                 return null;
             }
-
+            
             ASN1Sequence AccessDescriptions = (ASN1Sequence) obj;
             for (int i = 0; i < AccessDescriptions.size(); i++) {
                 ASN1Sequence AccessDescription = (ASN1Sequence) AccessDescriptions.getObjectAt(i);
                 if ( AccessDescription.size() != 2 ) {
                     continue;
                 } else {
+                    //TIBCO Software #9 : Part 10 - START
                     if ((AccessDescription.getObjectAt(0) instanceof ASN1ObjectIdentifier) && ((ASN1ObjectIdentifier)AccessDescription.getObjectAt(0)).getId().equals("1.3.6.1.5.5.7.48.1")) {
+                    //TIBCO Software #9 : Part 10 - END
                         // TIBCO Software #6 : Part 10 - START
                         String AccessLocation =  getStringFromGeneralName((ASN1Primitive)AccessDescription.getObjectAt(1));
                         // TIBCO Software #6 : Part 10 - END
@@ -995,7 +1009,7 @@ public class PdfPKCS7 {
         }
         return null;
     }
-
+    
     /**
      * Checks if OCSP revocation refers to the document signing certificate.
      * @return true if it checks false otherwise
@@ -1022,7 +1036,7 @@ public class PdfPKCS7 {
         return false;
 */    }
     // TIBCO Software #6 : Part 11 - END
-
+    
     // TIBCO Software #6 : Part 12 - START
     private static ASN1Primitive getExtensionValue(X509Certificate cert, String oid) throws IOException {
         // TIBCO Software #6 : Part 12 - END
@@ -1035,7 +1049,7 @@ public class PdfPKCS7 {
         aIn = new ASN1InputStream(new ByteArrayInputStream(octs.getOctets()));
         return aIn.readObject();
     }
-
+    
     // TIBCO Software #6 : Part 13 - START
     private static String getStringFromGeneralName(ASN1Primitive names) throws IOException {
         // TIBCO Software #6 : Part 13 - END
@@ -1110,7 +1124,7 @@ public class PdfPKCS7 {
             throw new ExceptionConverter(e);
         }
     }
-
+    
     /**
      * Gets the bytes for the PKCS#1 object.
      * @return a byte array
@@ -1122,18 +1136,18 @@ public class PdfPKCS7 {
             else
                 digest = sig.sign();
             ByteArrayOutputStream   bOut = new ByteArrayOutputStream();
-
+            
             ASN1OutputStream dout = new ASN1OutputStream(bOut);
             dout.writeObject(new DEROctetString(digest));
             dout.close();
-
+            
             return bOut.toByteArray();
         }
         catch (Exception e) {
             throw new ExceptionConverter(e);
         }
     }
-
+    
     /**
      * Sets the digest/signature to an external calculated value.
      * @param digest the digest. This is the actual signature
@@ -1141,7 +1155,7 @@ public class PdfPKCS7 {
      * @param digestEncryptionAlgorithm the encryption algorithm. It may must be <CODE>null</CODE> if the <CODE>digest</CODE>
      * is also <CODE>null</CODE>. If the <CODE>digest</CODE> is not <CODE>null</CODE>
      * then it may be "RSA" or "DSA"
-     */
+     */    
     public void setExternalDigest(byte digest[], byte RSAdata[], String digestEncryptionAlgorithm) {
         externalDigest = digest;
         externalRSAdata = RSAdata;
@@ -1156,7 +1170,7 @@ public class PdfPKCS7 {
                 throw new ExceptionConverter(new NoSuchAlgorithmException("Unknown Key Algorithm "+digestEncryptionAlgorithm));
         }
     }
-
+    
     /**
      * Gets the bytes for the PKCS7SignedData object.
      * @return the bytes for the PKCS7SignedData object
@@ -1164,7 +1178,7 @@ public class PdfPKCS7 {
     public byte[] getEncodedPKCS7() {
         return getEncodedPKCS7(null, null, null, null);
     }
-
+    
     /**
      * Gets the bytes for the PKCS7SignedData object. Optionally the authenticatedAttributes
      * in the signerInfo can also be set. If either of the parameters is <CODE>null</CODE>, none will be used.
@@ -1205,23 +1219,27 @@ public class PdfPKCS7 {
                 }
                 digest = sig.sign();
             }
-
+            
             // Create the set of Hash algorithms
             ASN1EncodableVector digestAlgorithms = new ASN1EncodableVector();
             for(Iterator it = digestalgos.iterator(); it.hasNext();) {
                 ASN1EncodableVector algos = new ASN1EncodableVector();
+                //TIBCO Software #9 : Part 11 - START
                 algos.add(new ASN1ObjectIdentifier((String)it.next()));
+                //TIBCO Software #9 : Part 11 - END
                 algos.add(DERNull.INSTANCE);
                 digestAlgorithms.add(new DERSequence(algos));
             }
-
+            
             // Create the contentInfo.
             ASN1EncodableVector v = new ASN1EncodableVector();
+            //TIBCO Software #9 : Part 12 - START
             v.add(new ASN1ObjectIdentifier(ID_PKCS7_DATA));
+            //TIBCO Software #9 : Part 12 - END
             if (RSAdata != null)
                 v.add(new DERTaggedObject(0, new DEROctetString(RSAdata)));
             DERSequence contentinfo = new DERSequence(v);
-
+            
             // Get all the certificates
             //
             v = new ASN1EncodableVector();
@@ -1229,28 +1247,29 @@ public class PdfPKCS7 {
                 ASN1InputStream tempstream = new ASN1InputStream(new ByteArrayInputStream(((X509Certificate)i.next()).getEncoded()));
                 v.add(tempstream.readObject());
             }
-
+            
             DERSet dercertificates = new DERSet(v);
-
+            
             // Create signerinfo structure.
             //
             ASN1EncodableVector signerinfo = new ASN1EncodableVector();
-
+            
             // Add the signerInfo version
             //
+            //TIBCO Software #9 : Part 13 - START
             signerinfo.add(new ASN1Integer(signerversion));
-
+            
             v = new ASN1EncodableVector();
             v.add(getIssuer(signCert.getTBSCertificate()));
             v.add(new ASN1Integer(signCert.getSerialNumber()));
             signerinfo.add(new DERSequence(v));
-
+            
             // Add the digestAlgorithm
             v = new ASN1EncodableVector();
             v.add(new ASN1ObjectIdentifier(digestAlgorithm));
             v.add(DERNull.INSTANCE);
             signerinfo.add(new DERSequence(v));
-
+            
             // add the authenticated attribute if present
             if (secondDigest != null && signingTime != null) {
                 signerinfo.add(new DERTaggedObject(false, 0, getAuthenticatedAttributeSet(secondDigest, signingTime, ocsp)));
@@ -1259,11 +1278,12 @@ public class PdfPKCS7 {
             v = new ASN1EncodableVector();
             v.add(new ASN1ObjectIdentifier(digestEncryptionAlgorithm));
             v.add(DERNull.INSTANCE);
+            //TIBCO Software #9 : Part 13 - END
             signerinfo.add(new DERSequence(v));
-
+            
             // Add the digest
             signerinfo.add(new DEROctetString(digest));
-
+            
             // When requested, go get and add the timestamp. May throw an exception.
             // Added by Martin Brunecky, 07/12/2007 folowing Aiken Sam, 2006-11-15
             // Sam found Adobe expects time-stamped SHA1-1 of the encrypted digest
@@ -1277,14 +1297,16 @@ public class PdfPKCS7 {
                     }
                 }
             }
-
+            
             // Finally build the body out of all the components above
             ASN1EncodableVector body = new ASN1EncodableVector();
+            //TIBCO Software #9 : Part 14 - START
             body.add(new ASN1Integer(version));
+            //TIBCO Software #9 : Part 14 - END
             body.add(new DERSet(digestAlgorithms));
             body.add(contentinfo);
             body.add(new DERTaggedObject(false, 0, dercertificates));
-
+            
            if (!crls.isEmpty()) {
                 v = new ASN1EncodableVector();
                 for (Iterator i = crls.iterator();i.hasNext();) {
@@ -1294,30 +1316,32 @@ public class PdfPKCS7 {
                 DERSet dercrls = new DERSet(v);
                 body.add(new DERTaggedObject(false, 1, dercrls));
             }
-
+            
             // Only allow one signerInfo
             body.add(new DERSet(new DERSequence(signerinfo)));
-
+            
             // Now we have the body, wrap it in it's PKCS7Signed shell
             // and return it
             //
             ASN1EncodableVector whole = new ASN1EncodableVector();
+            //TIBCO Software #9 : Part 15 - START
             whole.add(new ASN1ObjectIdentifier(ID_PKCS7_SIGNED_DATA));
+            //TIBCO Software #9 : Part 15 - END
             whole.add(new DERTaggedObject(0, new DERSequence(body)));
-
+            
             ByteArrayOutputStream   bOut = new ByteArrayOutputStream();
-
+            
             ASN1OutputStream dout = new ASN1OutputStream(bOut);
             dout.writeObject(new DERSequence(whole));
             dout.close();
-
+            
             return bOut.toByteArray();
         }
         catch (Exception e) {
             throw new ExceptionConverter(e);
         }
     }
-
+    
     /**
      * Added by Aiken Sam, 2006-11-15, modifed by Martin Brunecky 07/12/2007
      * to start with the timeStampToken (signedData 1.2.840.113549.1.7.2).
@@ -1338,7 +1362,9 @@ public class PdfPKCS7 {
         ASN1EncodableVector unauthAttributes = new ASN1EncodableVector();
 
         ASN1EncodableVector v = new ASN1EncodableVector();
+        //TIBCO Software #9 : Part 16 - START
         v.add(new ASN1ObjectIdentifier(ID_TIME_STAMP_TOKEN)); // id-aa-timeStampToken
+        //TIBCO Software #9 : Part 16 - END
         ASN1Sequence seq = (ASN1Sequence) tempstream.readObject();
         v.add(new DERSet(seq));
 
@@ -1346,7 +1372,7 @@ public class PdfPKCS7 {
         return unauthAttributes;
      }
 
-
+    
     /**
      * When using authenticatedAttributes the authentication process is different.
      * The document digest is generated and put inside the attribute. The signing is done over the DER encoded
@@ -1373,7 +1399,7 @@ public class PdfPKCS7 {
      * @param secondDigest the content digest
      * @param signingTime the signing time
      * @return the byte array representation of the authenticatedAttributes ready to be signed
-     */
+     */    
     public byte[] getAuthenticatedAttributeBytes(byte secondDigest[], Calendar signingTime, byte[] ocsp) {
         try {
             // TIBCO Software #6 : Part 18 - START
@@ -1384,11 +1410,12 @@ public class PdfPKCS7 {
             throw new ExceptionConverter(e);
         }
     }
-
+    
     private DERSet getAuthenticatedAttributeSet(byte secondDigest[], Calendar signingTime, byte[] ocsp) {
         try {
             ASN1EncodableVector attribute = new ASN1EncodableVector();
             ASN1EncodableVector v = new ASN1EncodableVector();
+            //TIBCO Software #9 : Part 17 - START
             v.add(new ASN1ObjectIdentifier(ID_CONTENT_TYPE));
             v.add(new DERSet(new ASN1ObjectIdentifier(ID_PKCS7_DATA)));
             attribute.add(new DERSequence(v));
@@ -1415,7 +1442,7 @@ public class PdfPKCS7 {
                 vo1.add(new DERSequence(v3));
                 v.add(new DERSet(new DERSequence(new DERTaggedObject(true, 1, new DERSequence(vo1)))));
                 attribute.add(new DERSequence(v));
-            }
+            }                
             else if (!crls.isEmpty()) {
                 v = new ASN1EncodableVector();
                 v.add(new ASN1ObjectIdentifier(ID_ADBE_REVOCATION));
@@ -1427,13 +1454,14 @@ public class PdfPKCS7 {
                 v.add(new DERSet(new DERSequence(new DERTaggedObject(true, 0, new DERSequence(v2)))));
                 attribute.add(new DERSequence(v));
             }
+            //TIBCO Software #9 : Part 17 - END
             return new DERSet(attribute);
         }
         catch (Exception e) {
             throw new ExceptionConverter(e);
         }
     }
-
+    
     /**
      * Getter for property reason.
      * @return Value of property reason.
@@ -1441,7 +1469,7 @@ public class PdfPKCS7 {
     public String getReason() {
         return this.reason;
     }
-
+    
     /**
      * Setter for property reason.
      * @param reason New value of property reason.
@@ -1449,7 +1477,7 @@ public class PdfPKCS7 {
     public void setReason(String reason) {
         this.reason = reason;
     }
-
+    
     /**
      * Getter for property location.
      * @return Value of property location.
@@ -1457,7 +1485,7 @@ public class PdfPKCS7 {
     public String getLocation() {
         return this.location;
     }
-
+    
     /**
      * Setter for property location.
      * @param location New value of property location.
@@ -1465,7 +1493,7 @@ public class PdfPKCS7 {
     public void setLocation(String location) {
         this.location = location;
     }
-
+    
     /**
      * Getter for property signDate.
      * @return Value of property signDate.
@@ -1473,7 +1501,7 @@ public class PdfPKCS7 {
     public Calendar getSignDate() {
         return this.signDate;
     }
-
+    
     /**
      * Setter for property signDate.
      * @param signDate New value of property signDate.
@@ -1481,7 +1509,7 @@ public class PdfPKCS7 {
     public void setSignDate(Calendar signDate) {
         this.signDate = signDate;
     }
-
+    
     /**
      * Getter for property sigName.
      * @return Value of property sigName.
@@ -1489,7 +1517,7 @@ public class PdfPKCS7 {
     public String getSignName() {
         return this.signName;
     }
-
+    
     /**
      * Setter for property sigName.
      * @param signName New value of property sigName.
@@ -1497,11 +1525,12 @@ public class PdfPKCS7 {
     public void setSignName(String signName) {
         this.signName = signName;
     }
-
+    
     /**
      * a class that holds an X509 name
      */
     public static class X509Name {
+        //TIBCO Software #9 : Part 18 - START
         /**
          * country code - StringType(SIZE(2))
          */
@@ -1569,10 +1598,11 @@ public class PdfPKCS7 {
 
         /** LDAP User id. */
         public static final ASN1ObjectIdentifier UID = new ASN1ObjectIdentifier("0.9.2342.19200300.100.1.1");
+        //TIBCO Software #9 : Part 18 - END
 
         /** A HashMap with default symbols */
         public static HashMap DefaultSymbols = new HashMap();
-
+        
         static {
             DefaultSymbols.put(C, "C");
             DefaultSymbols.put(O, "O");
@@ -1599,10 +1629,10 @@ public class PdfPKCS7 {
          */
         public X509Name(ASN1Sequence seq) {
             Enumeration e = seq.getObjects();
-
+            
             while (e.hasMoreElements()) {
                 ASN1Set set = (ASN1Set)e.nextElement();
-
+                
                 for (int i = 0; i < set.size(); i++) {
                     ASN1Sequence s = (ASN1Sequence)set.getObjectAt(i);
                     String id = (String)DefaultSymbols.get(s.getObjectAt(0));
@@ -1625,15 +1655,15 @@ public class PdfPKCS7 {
          */
         public X509Name(String dirName) {
             X509NameTokenizer   nTok = new X509NameTokenizer(dirName);
-
+            
             while (nTok.hasMoreTokens()) {
                 String  token = nTok.nextToken();
                 int index = token.indexOf('=');
-
+                
                 if (index == -1) {
                     throw new IllegalArgumentException("badly formated directory string");
                 }
-
+                
                 String id = token.substring(0, index).toUpperCase();
                 String value = token.substring(index + 1);
                 ArrayList vs = (ArrayList)values.get(id);
@@ -1643,9 +1673,9 @@ public class PdfPKCS7 {
                 }
                 vs.add(value);
             }
-
+            
         }
-
+        
         public String getField(String name) {
             ArrayList vs = (ArrayList)values.get(name);
             return vs == null ? null : (String)vs.get(0);
@@ -1660,7 +1690,7 @@ public class PdfPKCS7 {
             ArrayList vs = (ArrayList)values.get(name);
             return vs == null ? null : vs;
         }
-
+        
         /**
          * getter for values
          * @return a HashMap with the fields of the X509 name
@@ -1668,7 +1698,7 @@ public class PdfPKCS7 {
         public HashMap getFields() {
             return values;
         }
-
+        
         /**
          * @see java.lang.Object#toString()
          */
@@ -1676,7 +1706,7 @@ public class PdfPKCS7 {
             return values.toString();
         }
     }
-
+    
     /**
      * class for breaking up an X500 Name into it's component tokens, ala
      * java.util.StringTokenizer. We need this class as some of the
@@ -1687,31 +1717,31 @@ public class PdfPKCS7 {
         private String          oid;
         private int             index;
         private StringBuffer    buf = new StringBuffer();
-
+        
         public X509NameTokenizer(
         String oid) {
             this.oid = oid;
             this.index = -1;
         }
-
+        
         public boolean hasMoreTokens() {
             return (index != oid.length());
         }
-
+        
         public String nextToken() {
             if (index == oid.length()) {
                 return null;
             }
-
+            
             int     end = index + 1;
             boolean quoted = false;
             boolean escaped = false;
-
+            
             buf.setLength(0);
-
+            
             while (end != oid.length()) {
                 char    c = oid.charAt(end);
-
+                
                 if (c == '"') {
                     if (!escaped) {
                         quoted = !quoted;
@@ -1738,7 +1768,7 @@ public class PdfPKCS7 {
                 }
                 end++;
             }
-
+            
             index = end;
             return buf.toString().trim();
         }

--- a/core/com/lowagie/text/pdf/PdfPublicKeySecurityHandler.java
+++ b/core/com/lowagie/text/pdf/PdfPublicKeySecurityHandler.java
@@ -19,7 +19,7 @@
  * Co-Developer of the code is Paulo Soares. Portions created by the Co-Developer
  * are Copyright (C) 2000-2007 by Paulo Soares. All Rights Reserved.
  *
- * Contributor(s): Certain Contributions were created by TIBCO Software Inc. Such
+ * Contributor(s): Certain Contributions were created by TIBCO Software Inc. Such 
  * Contributions are Copyright (C) 2017 by TIBCO Software Inc. All Rights Reserved.
  * All the names of the other contributors are added in the source code
  * where applicable.
@@ -51,10 +51,10 @@
 
 /**
  *     The below 2 methods are from pdfbox.
- *
+ * 
  *     private DERObject createDERForRecipient(byte[] in, X509Certificate cert) ;
  *     private KeyTransRecipientInfo computeRecipientInfo(X509Certificate x509certificate, byte[] abyte0);
- *
+ *     
  *     2006-11-22 Aiken Sam.
  */
 
@@ -109,15 +109,17 @@ import javax.crypto.Cipher;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 
+//TIBCO Software #9 : Part 19 - START
+import org.bouncycastle.asn1.ASN1Encoding;
 import org.bouncycastle.asn1.ASN1InputStream;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.ASN1OutputStream;
 // TIBCO Software #6 : Part 20 - START
 import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.ASN1Set;
 //TIBCO Software #6 : Part 20 - END
-import org.bouncycastle.asn1.ASN1ObjectIdentifier;
-import org.bouncycastle.asn1.ASN1OutputStream;
 import org.bouncycastle.asn1.DEROctetString;
-//import org.bouncycastle.asn1.DEROutputStream;
+//TIBCO Software #9 : Part 19 - END
 import org.bouncycastle.asn1.DERSet;
 import org.bouncycastle.asn1.cms.ContentInfo;
 import org.bouncycastle.asn1.cms.EncryptedContentInfo;
@@ -134,11 +136,11 @@ import org.bouncycastle.asn1.x509.TBSCertificateStructure;
  * @author Aiken Sam (aikensam@ieee.org)
  */
 public class PdfPublicKeySecurityHandler {
-
+    
     static final int SEED_LENGTH = 20;
-
+    
     private ArrayList recipients = null;
-
+    
     private byte[] seed = new byte[SEED_LENGTH];
 
     public PdfPublicKeySecurityHandler() {
@@ -146,28 +148,28 @@ public class PdfPublicKeySecurityHandler {
         try {
             key = KeyGenerator.getInstance("AES");
             key.init(192, new SecureRandom());
-            SecretKey sk = key.generateKey();
-            System.arraycopy(sk.getEncoded(), 0, seed, 0, SEED_LENGTH); // create the 20 bytes seed
+            SecretKey sk = key.generateKey();            
+            System.arraycopy(sk.getEncoded(), 0, seed, 0, SEED_LENGTH); // create the 20 bytes seed            
         } catch (NoSuchAlgorithmException e) {
-            seed = SecureRandom.getSeed(SEED_LENGTH);
+            seed = SecureRandom.getSeed(SEED_LENGTH); 
         }
-
+    
         recipients = new ArrayList();
     }
 
 
-    /*
+    /* 
      * Routine for decode output of PdfContentByte.escapeString(byte[] bytes).
-     * It should be moved to PdfContentByte.
+     * It should be moved to PdfContentByte. 
      */
-
+     
     static public byte[] unescapedString(byte[] bytes) throws BadPdfFormatException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
+              
         int index = 0;
-
+        
         if (bytes[0] != '(' && bytes[bytes.length-1] != ')') throw new BadPdfFormatException("Expect '(' and ')' at begin and end of the string.");
-
+        
         while (index < bytes.length) {
             if (bytes[index] == '\\') {
                 index++;
@@ -192,7 +194,7 @@ public class PdfPublicKeySecurityHandler {
                         break;
                 case ')':
                         baos.write(')');
-                        break;
+                        break;                        
                 case '\\':
                     baos.write('\\');
                     break;
@@ -203,71 +205,73 @@ public class PdfPublicKeySecurityHandler {
         }
         return baos.toByteArray();
     }
-
+    
     public void addRecipient(PdfPublicKeyRecipient recipient) {
         recipients.add(recipient);
     }
-
+    
     protected byte[] getSeed() {
         return (byte[])seed.clone();
     }
     /*
     public PdfPublicKeyRecipient[] getRecipients() {
-        recipients.toArray();
-        return (PdfPublicKeyRecipient[])recipients.toArray();
+        recipients.toArray(); 
+        return (PdfPublicKeyRecipient[])recipients.toArray(); 
     }*/
-
+    
     public int getRecipientsSize() {
         return recipients.size();
     }
-
+    
     public byte[] getEncodedRecipient(int index) throws IOException, GeneralSecurityException {
         //Certificate certificate = recipient.getX509();
         PdfPublicKeyRecipient recipient = (PdfPublicKeyRecipient)recipients.get(index);
         byte[] cms = recipient.getCms();
-
+        
         if (cms != null) return cms;
-
+        
         Certificate certificate  = recipient.getCertificate();
-        int permission =  recipient.getPermission();//PdfWriter.AllowCopy | PdfWriter.AllowPrinting | PdfWriter.AllowScreenReaders | PdfWriter.AllowAssembly;
+        int permission =  recipient.getPermission();//PdfWriter.AllowCopy | PdfWriter.AllowPrinting | PdfWriter.AllowScreenReaders | PdfWriter.AllowAssembly;   
         int revision = 3;
-
+        
         permission |= revision==3 ? 0xfffff0c0 : 0xffffffc0;
         permission &= 0xfffffffc;
         permission += 1;
-
+      
         byte[] pkcs7input = new byte[24];
-
+        
         byte one = (byte)(permission);
         byte two = (byte)(permission >> 8);
         byte three = (byte)(permission >> 16);
         byte four = (byte)(permission >> 24);
 
         System.arraycopy(seed, 0, pkcs7input, 0, 20); // put this seed in the pkcs7 input
-
+                            
         pkcs7input[20] = four;
-        pkcs7input[21] = three;
+        pkcs7input[21] = three;                
         pkcs7input[22] = two;
         pkcs7input[23] = one;
-
+        
         // TIBCO Software #6 : Part 21 - START
         ASN1Primitive obj = createDERForRecipient(pkcs7input, (X509Certificate)certificate);
         // TIBCO Software #6 : Part 21 - END
-
+            
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        ASN1OutputStream k = ASN1OutputStream.create(baos);
-
-        k.writeObject(obj);
-
+            
+        //TIBCO Software #9 : Part 20 - START
+        ASN1OutputStream k = ASN1OutputStream.create(baos, ASN1Encoding.DER);
+        //TIBCO Software #9 : Part 20 - END
+            
+        k.writeObject(obj);  
+        
         cms = baos.toByteArray();
 
         recipient.setCms(cms);
-
-        return cms;
+        
+        return cms;    
     }
-
-    public PdfArray getEncodedRecipients() throws IOException,
+    
+    public PdfArray getEncodedRecipients() throws IOException, 
                                          GeneralSecurityException {
         PdfArray EncodedRecipients = new PdfArray();
         byte[] cms = null;
@@ -280,19 +284,19 @@ public class PdfPublicKeySecurityHandler {
         } catch (IOException e) {
             EncodedRecipients = null;
         }
-
+        
         return EncodedRecipients;
     }
-
+    
     // TIBCO Software #6 : Part 22 - START
-    private ASN1Primitive createDERForRecipient(byte[] in, X509Certificate cert)
+    private ASN1Primitive createDERForRecipient(byte[] in, X509Certificate cert) 
     // TIBCO Software #6 : Part 22 - END
-        throws IOException,
-               GeneralSecurityException
+        throws IOException,  
+               GeneralSecurityException 
     {
-
+        
         String s = "1.2.840.113549.3.2";
-
+        
         AlgorithmParameterGenerator algorithmparametergenerator = AlgorithmParameterGenerator.getInstance(s);
         AlgorithmParameters algorithmparameters = algorithmparametergenerator.generateParameters();
         ByteArrayInputStream bytearrayinputstream = new ByteArrayInputStream(algorithmparameters.getEncoded("ASN.1"));
@@ -309,32 +313,36 @@ public class PdfPublicKeySecurityHandler {
         DEROctetString deroctetstring = new DEROctetString(abyte1);
         KeyTransRecipientInfo keytransrecipientinfo = computeRecipientInfo(cert, secretkey.getEncoded());
         DERSet derset = new DERSet(new RecipientInfo(keytransrecipientinfo));
+        //TIBCO Software #9 : Part 21 - START
         AlgorithmIdentifier algorithmidentifier = new AlgorithmIdentifier(new ASN1ObjectIdentifier(s), derobject);
-        EncryptedContentInfo encryptedcontentinfo =
+        //TIBCO Software #9 : Part 21 - END
+        EncryptedContentInfo encryptedcontentinfo = 
             new EncryptedContentInfo(PKCSObjectIdentifiers.data, algorithmidentifier, deroctetstring);
         // TIBCO Software #6 : Part 24 - START
         EnvelopedData env = new EnvelopedData(null, derset, encryptedcontentinfo, (ASN1Set) null);
         // TIBCO Software #6 : Part 24 - END
-        ContentInfo contentinfo =
+        ContentInfo contentinfo = 
             new ContentInfo(PKCSObjectIdentifiers.envelopedData, env);
         // TIBCO Software #6 : Part 25 - START
-        return contentinfo.toASN1Primitive();
+        return contentinfo.toASN1Primitive();        
         // TIBCO Software #6 : Part 25 - END
     }
-
+    
     private KeyTransRecipientInfo computeRecipientInfo(X509Certificate x509certificate, byte[] abyte0)
         throws GeneralSecurityException, IOException
     {
-        ASN1InputStream asn1inputstream =
+        ASN1InputStream asn1inputstream = 
             new ASN1InputStream(new ByteArrayInputStream(x509certificate.getTBSCertificate()));
-        TBSCertificateStructure tbscertificatestructure =
+        TBSCertificateStructure tbscertificatestructure = 
             TBSCertificateStructure.getInstance(asn1inputstream.readObject());
         AlgorithmIdentifier algorithmidentifier = tbscertificatestructure.getSubjectPublicKeyInfo().getAlgorithmId();
-        IssuerAndSerialNumber issuerandserialnumber =
+        IssuerAndSerialNumber issuerandserialnumber = 
             new IssuerAndSerialNumber(
-                tbscertificatestructure.getIssuer(),
+                tbscertificatestructure.getIssuer(), 
                 tbscertificatestructure.getSerialNumber().getValue());
-        Cipher cipher = Cipher.getInstance(algorithmidentifier.getAlgorithm().getId());
+        // TIBCO Software #7 : Part 1 - START
+        Cipher cipher = Cipher.getInstance(algorithmidentifier.getAlgorithm().getId());        
+        // TIBCO Software #7 : Part 1 - END
         cipher.init(1, x509certificate);
         DEROctetString deroctetstring = new DEROctetString(cipher.doFinal(abyte0));
         RecipientIdentifier recipId = new RecipientIdentifier(issuerandserialnumber);

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
      </properties>
 
 	<name>iText, a Free Java-PDF library</name>
-	<version>2.1.7.js7.SEE4-SNAPSHOT</version>
+	<version>2.1.7.js9.SEE1-SNAPSHOT</version>
 	<description>iText, a free Java-PDF library</description>
 	<url>http://www.lowagie.com/iText/</url>
 	<mailingLists>


### PR DESCRIPTION
Synchronized sources to be the same as teh JS9 version:
https://jaspersoft.jfrog.io/artifactory/third-party-ce-artifacts/com/lowagie/itext/2.1.7.js9/itext-2.1.7.js9-sources.jar