### PR TITLE
[Feature #160177] Update the iText fork version (sync to 2.1.7.js10)

### DIFF
--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -1,4 +1,4 @@
 Manifest-Version: 1.0
-Ant-Version: Apache Ant 1.9.6
-Created-By: 1.8.0_191-b12 (Oracle Corporation)
+Ant-Version: Apache Ant 1.10.11
+Created-By: 11.0.13+10-LTS-370 (Oracle Corporation)
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,24 @@ http://jaspersoft.jfrog.io/jaspersoft/third-party-ce-artifacts/com/lowagie/itext
 specifically source JAR:
 http://jaspersoft.jfrog.io/jaspersoft/third-party-ce-artifacts/com/lowagie/itext/2.1.7.js7/itext-2.1.7.js7-sources.jar
 
-Later the sources were updated to be the same as those of js9:
+Later the sources were updated to be the same as those of
+
+1. js9:
 https://jaspersoft.jfrog.io/ui/native/third-party-ce-artifacts/com/lowagie/itext/2.1.7.js9/
 specifically source JAR:
 https://jaspersoft.jfrog.io/artifactory/third-party-ce-artifacts/com/lowagie/itext/2.1.7.js9/itext-2.1.7.js9-sources.jar
 
-Seeburger changes include making it compatible with newer versions of the BouncyCastle cryptography provider:
+2. js10:
+https://jaspersoft.jfrog.io/artifactory/third-party-ce-artifacts/com/lowagie/itext/2.1.7.js10/
+specifically source JAR:
+https://jaspersoft.jfrog.io/artifactory/third-party-ce-artifacts/com/lowagie/itext/2.1.7.js10/itext-2.1.7.js10-sources.jar
+
+
+Seeburger changes include making it compatible with newer versions of the BouncyCastle cryptography provider,
+as well as security hardening for XML parsers:
 
 ```
-24.02.2021, modified:
+24 Feb 2021, modified:
 core/com/lowagie/text/XMLUtil.java
 core/com/lowagie/text/pdf/XfaForm.java
 core/com/lowagie/text/xml/TagMap.java
@@ -39,4 +48,8 @@ core/com/lowagie/text/pdf/PdfPublicKeySecurityHandler.java
 Purpose: Synchronizing sources to be the same as version JS9
 https://jaspersoft.jfrog.io/artifactory/third-party-ce-artifacts/com/lowagie/itext/2.1.7.js9/itext-2.1.7.js9-sources.jar
 
+10 May 2023
+core/com/lowagie/text/pdf/PdfPKCS7.java
+Purpose: Synchronizing sources to be the same as version JS10
+https://jaspersoft.jfrog.io/artifactory/third-party-ce-artifacts/com/lowagie/itext/2.1.7.js10/itext-2.1.7.js10-sources.jar
 ```

--- a/ant/.ant.properties
+++ b/ant/.ant.properties
@@ -14,11 +14,12 @@ jcommon.jar=${itext.lib}/jcommon.jar
 servlet.jar=${itext.lib}/servlet.jar
 
 bc.jdk=jdk15on
-bc.version=1.62
+bc.version=1.70
 
 lib.bcmail=bcmail-${bc.jdk}-${bc.version}.jar
 lib.bcprov=bcprov-${bc.jdk}-${bc.version}.jar
 lib.bcpkix=bcpkix-${bc.jdk}-${bc.version}.jar
+lib.bcutil=bcutil-${bc.jdk}-${bc.version}.jar
 lib.dom4j=pdf-renderer.jar
 lib.pdf-renderer=dom4j-1.6.1.jar
 

--- a/ant/compile.xml
+++ b/ant/compile.xml
@@ -16,6 +16,7 @@
 		    <pathelement path="${itext.lib}/${lib.bcmail}"/>
 	    <pathelement path="${itext.lib}/${lib.bcprov}"/>
 	    <pathelement path="${itext.lib}/${lib.bcpkix}"/>
+	    <pathelement path="${itext.lib}/${lib.bcutil}"/>
 		<!-- jars needed for RUPS -->
 	    <pathelement path="${itext.lib}/${lib.pdf-renderer}"/>
 	    <pathelement path="${itext.lib}/${lib.dom4j}"/>

--- a/core/TIBCO.Software.changes.txt
+++ b/core/TIBCO.Software.changes.txt
@@ -44,6 +44,7 @@ com/lowagie/text/pdf/PdfReader.java
 Date: July 3, 2019
 Modified files:
 com/lowagie/text/pdf/PdfPublicKeySecurityHandler
+
 #8 Upgrade Bouncy Castle dependencies to jdk15on-1.64
 Date: June 30, 2020
 Modified files:
@@ -54,3 +55,8 @@ Date: September 21, 2021
 Modified files:
 com/lowagie/text/pdf/PdfPKCS7.java
 com/lowagie/text/pdf/PdfPublicKeySecurityHandler.java
+
+#10 Upgrade Bouncy Castle dependencies to jdk15on-1.70
+Date: June 06, 2022
+Modified files:
+com/lowagie/text/pdf/PdfPKCS7.java

--- a/core/com/lowagie/text/pdf/PdfPKCS7.java
+++ b/core/com/lowagie/text/pdf/PdfPKCS7.java
@@ -520,8 +520,9 @@ public class PdfPKCS7 {
                 Attribute ts = attble.get(PKCSObjectIdentifiers.id_aa_signatureTimeStampToken);
                 if (ts != null) {
                     ASN1Set attributeValues = ts.getAttrValues();
-                    ASN1Sequence tokenSequence = ASN1Sequence.getInstance(attributeValues.getObjectAt(0));
-                    ContentInfo contentInfo = ContentInfo.getInstance(tokenSequence);
+                    //TIBCO Software #10 : Part 1 - START
+                    ContentInfo contentInfo = ContentInfo.getInstance(attributeValues.getObjectAt(0));
+                    //TIBCO Software #10 : Part 1 - END
                     this.timeStampToken = new TimeStampToken(contentInfo);
                 }
             }
@@ -1137,7 +1138,9 @@ public class PdfPKCS7 {
                 digest = sig.sign();
             ByteArrayOutputStream   bOut = new ByteArrayOutputStream();
 
+            //TIBCO Software #10 : Part 2 - START
             ASN1OutputStream dout = ASN1OutputStream.create(bOut);
+            //TIBCO Software #10 : Part 2 - END
             dout.writeObject(new DEROctetString(digest));
             dout.close();
 
@@ -1331,7 +1334,9 @@ public class PdfPKCS7 {
 
             ByteArrayOutputStream   bOut = new ByteArrayOutputStream();
 
+            //TIBCO Software #10 : Part 3 - START
             ASN1OutputStream dout = ASN1OutputStream.create(bOut);
+            //TIBCO Software #10 : Part 3 - END
             dout.writeObject(new DERSequence(whole));
             dout.close();
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,9 @@
 	<packaging>jar</packaging>
 
 	 <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+
         <bc.version>1.70</bc.version>
         <osgi.imported.packages>
             !junit,
@@ -21,7 +24,7 @@
      </properties>
 
 	<name>iText, a Free Java-PDF library</name>
-	<version>2.1.7.js9.SEE3-SNAPSHOT</version>
+	<version>2.1.7.js10.SEE1-SNAPSHOT</version>
 	<description>iText, a free Java-PDF library</description>
 	<url>http://www.lowagie.com/iText/</url>
 	<mailingLists>


### PR DESCRIPTION
Changes are: synchronized sources with upstream version  2.1.7.js10, and updated maven build for JDK 11.
